### PR TITLE
Add functional substitution generator

### DIFF
--- a/generation/src/proof_generation/basic_interpreter.py
+++ b/generation/src/proof_generation/basic_interpreter.py
@@ -124,6 +124,10 @@ class BasicInterpreter:
                 self.patterns(app_ctx_holes)
 
                 return self.metavar(name, e_fresh, s_fresh, positive, negative, app_ctx_holes)
+            case ESubst(pattern, var, plug):
+                self.esubst(var.name, pattern, plug)
+            case SSubst(pattern, var, plug):
+                self.ssubst(var.name, pattern, plug)
 
         if isinstance(p, Notation):
             if isinstance(p, NotationPlaceholder):

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -461,13 +461,15 @@ class Notation(Pattern, ABC):
         return type(self)(*final_args)
 
     def apply_esubst(self, evar_id: int, plug: Pattern) -> Pattern:
-        for arg in vars(self).keys():
-            self.__setattr__(arg, apply_esubst(evar_id, plug))
+        for (argname, arg) in vars(self).items():
+            if isinstance(arg, Pattern):
+                self.__setattr__(argname, arg.apply_esubst(evar_id, plug))
         return self
 
     def apply_ssubst(self, svar_id: int, plug: Pattern) -> Pattern:
-        for arg in vars(self).keys():
-            self.__setattr__(arg, apply_ssubst(svar_id, plug))
+        for (argname, arg) in vars(self).items():
+            if isinstance(arg, Pattern):
+                self.__setattr__(argname, arg.apply_ssubst(svar_id, plug))
         return self
 
     @classmethod

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -106,7 +106,7 @@ class EVar(Pattern):
         return name != self.name
 
     def sf(self, name: int) -> bool:
-        raise True
+        return True
 
     def instantiate(self, delta: dict[int, Pattern]) -> Pattern:
         return self
@@ -139,7 +139,7 @@ class SVar(Pattern):
         return True
 
     def sf(self, name: int) -> bool:
-        raise name != self.name
+        return name != self.name
 
     def instantiate(self, delta: dict[int, Pattern]) -> Pattern:
         return self
@@ -172,7 +172,7 @@ class Symbol(Pattern):
         return True
 
     def sf(self, name: int) -> bool:
-        raise True
+        return True
 
     def instantiate(self, delta: dict[int, Pattern]) -> Pattern:
         return self
@@ -204,7 +204,7 @@ class Implies(Pattern):
         return self.left.ef(name) and self.right.ef(name)
 
     def sf(self, name: int) -> bool:
-        raise self.left.sf(name) and self.right.sf(name)
+        return self.left.sf(name) and self.right.sf(name)
 
     def instantiate(self, delta: dict[int, Pattern]) -> Pattern:
         return Implies(self.left.instantiate(delta), self.right.instantiate(delta))
@@ -232,7 +232,7 @@ class App(Pattern):
         return self.left.ef(name) and self.right.ef(name)
 
     def sf(self, name: int) -> bool:
-        raise self.left.sf(name) and self.right.sf(name)
+        return self.left.sf(name) and self.right.sf(name)
 
     def instantiate(self, delta: dict[int, Pattern]) -> Pattern:
         return App(self.left.instantiate(delta), self.right.instantiate(delta))

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -244,7 +244,7 @@ class App(Pattern):
         return App(self.left.apply_ssubst(svar_id, plug), self.right.apply_ssubst(svar_id, plug))
 
     def __str__(self) -> str:
-        return f'app({str(self.left)}, {str(self.right)})'
+        return f'({str(self.left)} · {str(self.right)})'
 
 
 @dataclass(frozen=True)

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -485,13 +485,13 @@ class Notation(Pattern, ABC):
         return type(self)(*final_args)
 
     def apply_esubst(self, evar_id: int, plug: Pattern) -> Pattern:
-        for (argname, arg) in vars(self).items():
+        for argname, arg in vars(self).items():
             if isinstance(arg, Pattern):
                 self.__setattr__(argname, arg.apply_esubst(evar_id, plug))
         return self
 
     def apply_ssubst(self, svar_id: int, plug: Pattern) -> Pattern:
-        for (argname, arg) in vars(self).items():
+        for argname, arg in vars(self).items():
             if isinstance(arg, Pattern):
                 self.__setattr__(argname, arg.apply_ssubst(svar_id, plug))
         return self

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -328,7 +328,7 @@ class MetaVar(Pattern):
         return EVar(name) in self.e_fresh
 
     def sf(self, name: int) -> bool:
-        return EVar(name) in self.s_fresh
+        return SVar(name) in self.s_fresh
 
     def can_be_replaced_by(self, pat: Pattern) -> bool:
         # TODO implement this function by checking constraints

--- a/generation/src/proof_generation/pattern.py
+++ b/generation/src/proof_generation/pattern.py
@@ -462,12 +462,12 @@ class Notation(Pattern, ABC):
 
     def apply_esubst(self, evar_id: int, plug: Pattern) -> Pattern:
         for arg in vars(self).keys():
-            self[arg] = arg.apply_esubst(evar_id, plug)
+            self.__setattr__(arg, apply_esubst(evar_id, plug))
         return self
 
     def apply_ssubst(self, svar_id: int, plug: Pattern) -> Pattern:
         for arg in vars(self).keys():
-            self[arg] = arg.apply_ssubst(svar_id, plug)
+            self.__setattr__(arg, apply_ssubst(svar_id, plug))
         return self
 
     @classmethod

--- a/generation/src/proof_generation/proofs/kore_lemmas.py
+++ b/generation/src/proof_generation/proofs/kore_lemmas.py
@@ -4,7 +4,7 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from proof_generation.pattern import App, MetaVar, Notation, Symbol
+from proof_generation.pattern import App, MetaVar, Notation, Symbol, EVar
 from proof_generation.proof import ProofExp
 from proof_generation.proofs.propositional import And, Negation, Or
 
@@ -155,6 +155,18 @@ class KoreLemmas(ProofExp):
 
     def proof_expressions(self) -> list[ProvedExpression]:
         return []
+
+
+@dataclass(frozen=True, eq=False)
+class KoreCell(Notation):
+    sym: Symbol
+    cell_contents: Pattern
+
+    def object_definition(cls) -> Pattern:
+        return App(self.symbol, cell_contents)
+
+    def __str__(self) -> str:
+        return f'<{self.sym.name}>{str(self.cell_contents)}</{self.sym.name}>'
 
 
 if __name__ == '__main__':

--- a/generation/src/proof_generation/proofs/substitution.py
+++ b/generation/src/proof_generation/proofs/substitution.py
@@ -4,8 +4,8 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from proof_generation.pattern import EVar, Exists, Notation
-from proof_generation.proofs.propositional import Propositional, neg, phi0, top
+from proof_generation.pattern import EVar, Exists, Notation, ESubst
+from proof_generation.proofs.propositional import Propositional, neg, phi0, phi1, top
 
 if TYPE_CHECKING:
     from proof_generation.pattern import Pattern
@@ -61,12 +61,14 @@ class Substitution(Propositional):
         """
         return self.universal_gen(self.top_intro, EVar(0))
 
-    def functional_subst(self, phi: ProvedExpression, phi1: ProvedExpression, x: EVar) -> ProvedExpression:
+    def functional_subst(self, phi: ProvedExpression, psi: ProvedExpression, x: EVar) -> ProvedExpression:
         """
         --------------------------------------
-        (exists x . phi1 = x) -> ((forall x. phi) -> phi[phi1/x])
+        (exists x . psi = x) -> ((forall x. phi) -> phi[psi/x])
         """
-        raise NotImplementedError
+        return self.load_axiom(
+            Implies(Exists(0, phi0), Forall(0, phi0), phi0)
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Implement `sf` in the DSL
- Fix `apply_esubst` and `apply_ssubst` in some places
- Implement apply step using functional substitution as an axiom for now
- Rename prettyprinted "app phi0 phi1" to the infix notation "phi0 · phi1", it's much more compact and prettier (f · 1 vs. app f 1, not to mention cells + contexts like (app <k> 1 </k> x0) vs. <k> 1 </k> · x0
- Adds `KoreCell`

*Code review*
I have yet to finish a single test for `apply_subst`