### PR TITLE
Add a minor improvement to the interface of `proof_gen`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,12 +286,12 @@ KGEN_PROOF_TRANSLATION_TARGETS=$(addsuffix .kgenerate,${TRANSLATED_FROM_K})
 module=$(patsubst %/,%, $(dir $*))
 proofs/generated-from-k/%.ml-proof.kgenerate: .build/kompiled-definitions/$$(module)-kompiled/timestamp .build/proof-hints/%.hints proofs/generated-from-k/%.ml-proof
 	$(POETRY_RUN) python -m "proof_generation.k.proof_gen" \
-	              generation/k-benchmarks/$(dir $*)$(module).k \
+	              $(module) \
 				  .build/proof-hints/$*.hints \
 				  .build/kompiled-definitions/$(module)-kompiled \
 				  --proof-dir proofs/generated-from-k/$(dir $*)
 	$(POETRY_RUN) python -m "proof_generation.k.proof_gen" \
-	              generation/k-benchmarks/$(dir $*)$(module).k \
+	              $(module) \
 				  .build/proof-hints/$*.hints \
 				  .build/kompiled-definitions/$(module)-kompiled \
 				  --proof-dir proofs/generated-from-k/$(dir $*) \
@@ -308,14 +308,14 @@ update-k-proofs: ${KGEN_PROOF_TRANSLATION_TARGETS}
 module=$(patsubst %/,%, $(dir $*))
 .build/proofs/generated-from-k/%.ml-proof: FORCE .build/kompiled-definitions/$$(module)-kompiled/timestamp .build/proof-hints/%.hints
 	$(POETRY_RUN) python -m "proof_generation.k.proof_gen" \
-	              generation/k-benchmarks/$(dir $*)$(module).k \
+	              $(module) \
 				  .build/proof-hints/$*.hints \
 				  .build/kompiled-definitions/$(module)-kompiled \
 				  --proof-dir .build/proofs/generated-from-k/$(dir $*)
 
 .build/proofs/generated-from-k/%.pretty-proof: FORCE .build/kompiled-definitions/$$(module)-kompiled/timestamp .build/proof-hints/%.hints
 	$(POETRY_RUN) python -m "proof_generation.k.proof_gen" \
-	              generation/k-benchmarks/$(dir $*)$(module).k \
+	              $(module) \
 				  .build/proof-hints/$*.hints \
 				  .build/kompiled-definitions/$(module)-kompiled \
 				  --proof-dir .build/proofs/generated-from-k/$(dir $*) \

--- a/generation/src/proof_generation/k/execution_proof_generation.py
+++ b/generation/src/proof_generation/k/execution_proof_generation.py
@@ -246,7 +246,7 @@ class ExecutionProofExp(proof.ProofExp):
                 raise NotImplementedError('TODO: Add support for equational rules')
 
         if proof_expr is None:
-            print('WARNING: The proof expression is empty, ho hints were provided.')
+            print('WARNING: The proof expression is empty, no hints were provided.')
             return proof.ProofExp(notations=list(language_semantics.notations))
         else:
             return proof_expr

--- a/generation/src/proof_generation/k/proof_gen.py
+++ b/generation/src/proof_generation/k/proof_gen.py
@@ -66,14 +66,14 @@ def get_axiom_label(attrs: tuple[kore.App, ...]) -> str:
 
 
 def main(
-    k_file: str,
+    module: str,
     hints_file: str,
-    output_dir: str,
+    kompiled: str,
     proof_dir: str,
     pretty: bool = False,
 ) -> None:
     # Kompile sources
-    kompiled_dir: Path = get_kompiled_dir(output_dir)
+    kompiled_dir: Path = get_kompiled_dir(kompiled)
     kore_definition = get_kompiled_definition(kompiled_dir)
 
     print('Begin converting ... ')
@@ -84,16 +84,16 @@ def main(
 
     print('Begin generating proofs ... ')
     kore_def = ExecutionProofExp.from_proof_hints(hints_iterator, language_semantics)
-    slice_name = Path(hints_file).stem + '.' + Path(k_file).stem
+    slice_name = Path(hints_file).stem + '.' + module
     generate_proof_file(kore_def, Path(proof_dir), slice_name, pretty)
     print('Done!')
 
 
 if __name__ == '__main__':
     argparser = ArgumentParser()
-    argparser.add_argument('kfile', type=str, help='Path to the K definition file')
+    argparser.add_argument('module', type=str, help='The module name')
     argparser.add_argument('hints', type=str, help='Path to the binary hints file')
-    argparser.add_argument('output_dir', type=str, help='Path to the output directory')
+    argparser.add_argument('kompiled', type=str, help='Path to the kompiled directory')
     argparser.add_argument('--proof-dir', type=str, default=str(Path.cwd()), help='Output directory for saving proofs')
     argparser.add_argument(
         '--pretty',
@@ -103,4 +103,4 @@ if __name__ == '__main__':
     )
 
     args = argparser.parse_args()
-    main(args.kfile, args.hints, args.output_dir, args.proof_dir, args.pretty)
+    main(args.module, args.hints, args.kompiled, args.proof_dir, args.pretty)


### PR DESCRIPTION
This PR:
1. renames `output_dir` to `kompiled` to better reflect the intended meaning (`proof_gen`)
2. replaces the `kfile` argument with the `module` name since the proof generator does not really need access to the k file (`proof_gen`)
3. Fixes a typo (`execution_proof_generation`)