### PR TITLE
Using `std::memset` instead of our own `memset_` implementation.

### DIFF
--- a/cpp/include/data_structures.hpp
+++ b/cpp/include/data_structures.hpp
@@ -1,17 +1,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
-
-void *memset_(void *ptr, int value, size_t num) {
-  auto *byte_ptr = (unsigned char *)ptr;
-  auto byte_value = (unsigned char)value;
-
-  for (size_t i = 0; i < num; i++) {
-    byte_ptr[i] = byte_value;
-  }
-
-  return ptr;
-}
+#include <cstring>
 
 template <typename T> struct Node {
   T data;
@@ -32,7 +22,7 @@ template <typename T> struct Node {
 
   static Node *create(const T &value) noexcept {
     Node *newNode = static_cast<Node *>(std::malloc(sizeof(Node)));
-    memset_(newNode, 0, sizeof(Node));
+    std::memset(newNode, 0, sizeof(Node));
     newNode->data = value;
     newNode->next = nullptr;
     return newNode;
@@ -209,7 +199,7 @@ using Id = int;
 class IdList : public LinkedList<Id> {
 public:
   IdList() noexcept : LinkedList<Id>() {
-    memset_(this, 0, sizeof(IdList));
+    std::memset(this, 0, sizeof(IdList));
   }
 
   IdList(const Id &value) noexcept : LinkedList<Id>(){

--- a/cpp/src/lib.hpp
+++ b/cpp/src/lib.hpp
@@ -138,7 +138,7 @@ struct Pattern {
   // Constructor for creating instances of Pattern
   static Pattern *newPattern(Instruction inst, Id id) noexcept {
     auto pattern = static_cast<Pattern *>(malloc(sizeof(Pattern)));
-    memset_(pattern, 0, sizeof(Pattern));
+    std::memset(pattern, 0, sizeof(Pattern));
 
     pattern->id = id;
     pattern->inst = inst;


### PR DESCRIPTION
This PR is part of #624!
It updates our zkllvm proof-checker to work with the new version of zkllvm. It's now possible to run assigner again without breaking with error (besides an eventual lack of memory);